### PR TITLE
add RandNif.uniform_noop

### DIFF
--- a/bench/comparison.exs
+++ b/bench/comparison.exs
@@ -32,6 +32,15 @@ defmodule RandNif.Bench.Comparison do
             end
           )
         end,
+        "RandNif.uniform_noop/0" => fn ->
+          unquote(
+            for _ <- 1..@n do
+              quote do
+                RandNif.uniform_noop()
+              end
+            end
+          )
+        end,
         "RandNif.uniform/1" => fn ->
           unquote(
             for _ <- 1..@n do

--- a/lib/rand_nif.ex
+++ b/lib/rand_nif.ex
@@ -14,6 +14,9 @@ defmodule RandNif do
 
   def uniform(), do: :erlang.nif_error(:nif_not_loaded)
 
+  @doc false
+  def uniform_noop(), do: :erlang.nif_error(:nif_not_loaded)
+
   @doc """
   Return a positive integer within specified range, similar to `:rand.uniform/1`.
 

--- a/native/randnif/src/lib.rs
+++ b/native/randnif/src/lib.rs
@@ -8,12 +8,18 @@ use rand::{thread_rng, Rng};
 rustler_export_nifs! {
     "Elixir.RandNif",
     [("uniform", 0, uniform_0),
+     ("uniform_noop", 0, uniform_noop_0),
      ("uniform", 1, uniform_1)],
     None
 }
 
 fn uniform_0<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Term<'a>> {
     Ok(thread_rng().gen::<f64>().encode(env))
+}
+
+fn uniform_noop_0<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Term<'a>> {
+    let x: f64 = 0.0;
+    Ok(x.encode(env))
 }
 
 fn uniform_1<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {


### PR DESCRIPTION

benchmarks with `RandNif.uniform_noop`:

`RandNif.uniform_noop/0` is a Nif function always return `0.0`, which is used to compare with `RandNif.uniform/0` to estimate the cost of Nif function call.

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-3720QM CPU @ 2.60GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.8.1
Erlang 21.2.4

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 1.42 min


Benchmarking :rand.uniform/0...
Benchmarking :rand.uniform/1...
Benchmarking RandNif.uniform/0...
Benchmarking RandNif.uniform/1...
Benchmarking RandNif.uniform_noop/0...

Name                             ips        average  deviation         median         99th %
RandNif.uniform_noop/0      194.10 K        5.15 μs   ±246.65%        4.29 μs       11.49 μs
RandNif.uniform/0           129.28 K        7.74 μs   ±191.82%        6.52 μs       15.12 μs
RandNif.uniform/1            66.18 K       15.11 μs    ±41.98%       13.29 μs       28.75 μs
:rand.uniform/0              41.38 K       24.16 μs    ±62.56%       22.13 μs       46.34 μs
:rand.uniform/1              36.52 K       27.39 μs    ±44.29%       24.84 μs       46.85 μs

Comparison: 
RandNif.uniform_noop/0      194.10 K
RandNif.uniform/0           129.28 K - 1.50x slower
RandNif.uniform/1            66.18 K - 2.93x slower
:rand.uniform/0              41.38 K - 4.69x slower
:rand.uniform/1              36.52 K - 5.32x slower

Memory usage statistics:

Name                      Memory usage
RandNif.uniform_noop/0         3.11 KB
RandNif.uniform/0              3.11 KB - 1.00x memory usage
RandNif.uniform/1              1.56 KB - 0.50x memory usage
:rand.uniform/0               11.97 KB - 3.85x memory usage
:rand.uniform/1               10.41 KB - 3.35x memory usage

**All measurements for memory usage were the same**
```

it seems that cost of Nif function is about 67% (5.15 / 7.74) for `RandNif.uniform/0`.